### PR TITLE
fix fused matmul op by op file

### DIFF
--- a/paddle/fluid/operators/fused/fused_matmul_op.cc
+++ b/paddle/fluid/operators/fused/fused_matmul_op.cc
@@ -194,6 +194,9 @@ class FusedMatmulOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<float>("fused_output_scale",
                    "Output scale from operator_scale_onednn_fuse_pass")
         .SetDefault(1.0f);
+    AddAttr<bool>("use_mkldnn",
+                  "(bool, default false) Only used in mkldnn kernel")
+        .SetDefault(false);
     AddAttr<std::vector<int>>("fused_reshape_X",
                               "Reshape's shape attribute from "
                               "reshape_transpose_matmul_mkldnn_fuse_pass")


### PR DESCRIPTION
In this method, directly add AddAttr<bool>("use_mkldnn") in fused_matmul_op.cc
