### PR TITLE
fix fused_matmul by add op extra info in YAML

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -1151,6 +1151,10 @@
     attrs : [bool use_cudnn = false, float fuse_alpha = 0.0f, float fuse_beta = 0.0f, float Scale_in = 1.0f,
              float Scale_out = 1.0f, float Scale_in_eltwise = 1.0f, 'float[] Scale_weights = {1.0f}']
 
+- op : fused_matmul
+  extra :
+    attrs : [bool use_mkldnn = false]
+
 - op : fused_transpose
   extra :
     attrs : [str data_format = "AnyLayout"]


### PR DESCRIPTION
In this method, add use_mkldnn attr by YAML file, these extra attr info will load by block_desc when append_op
